### PR TITLE
Improve error handling

### DIFF
--- a/Component code
+++ b/Component code
@@ -43,9 +43,11 @@ export function SlaterChat() {
             const reply = data.reply || "Sorry, I didn’t get that."
             setMsgs((prev) => [...prev, { role: "assistant", text: reply }])
         } catch (err) {
+            console.error(err)
+            const msg = err instanceof Error ? err.message : "Unknown error"
             setMsgs((prev) => [
                 ...prev,
-                { role: "assistant", text: "Error: API unreachable." },
+                { role: "assistant", text: `Error: ${msg}` },
             ])
         }
     }


### PR DESCRIPTION
## Summary
- show real errors if API call fails

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686e798f4210833386b95f4c0e7c135c